### PR TITLE
Uart rx

### DIFF
--- a/data/pins_artya7.xdc
+++ b/data/pins_artya7.xdc
@@ -88,7 +88,7 @@ set_property -dict { PACKAGE_PIN T10   IOSTANDARD LVCMOS33 } [get_ports { LED[3]
 
 ## USB-UART Interface
 set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { UART_TX }]; #IO_L19N_T3_VREF_16 Sch=uart_rxd_out
-#set_property -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports { uart_txd_in }]; #IO_L14N_T2_SRCC_16 Sch=uart_txd_in
+set_property -dict { PACKAGE_PIN A9    IOSTANDARD LVCMOS33 } [get_ports { UART_RX }]; #IO_L14N_T2_SRCC_16 Sch=uart_txd_in
 
 ## ChipKit Outer Digital Header
 #set_property -dict { PACKAGE_PIN V15   IOSTANDARD LVCMOS33 } [get_ports { ck_io0  }]; #IO_L16P_T2_CSI_B_14 Sch=ck_io[0]

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -10,3 +10,4 @@ git+https://github.com/lowRISC/fusesoc.git@ot
 
 pyyaml
 mako
+pyserial

--- a/rtl/fpga/top_artya7.sv
+++ b/rtl/fpga/top_artya7.sv
@@ -7,6 +7,7 @@ module top_artya7 (
     input               IO_RST_N,
     output [3:0]        LED,
     output [11:0]       RGB_LED,
+    input               UART_RX,
     output              UART_TX
 );
   parameter              SRAMInitFile = "";
@@ -22,6 +23,7 @@ module top_artya7 (
     .rst_sys_ni(rst_sys_n),
 
     .gp_o({LED, RGB_LED}),
+    .uart_rx_i(UART_RX),
     .uart_tx_o(UART_TX)
   );
 

--- a/rtl/system/ibex_super_system.sv
+++ b/rtl/system/ibex_super_system.sv
@@ -6,6 +6,7 @@ module ibex_super_system #(
   input logic                 rst_sys_ni,
 
   output logic [GpoWidth-1:0] gp_o,
+  input  logic                uart_rx_i,
   output logic                uart_tx_o
 );
   parameter logic [31:0] MEM_SIZE     = 64 * 1024; // 64 kB
@@ -92,6 +93,8 @@ module ibex_super_system #(
   logic [31:0] dbg_slave_wdata;
   logic        dbg_slave_rvalid;
   logic [31:0] dbg_slave_rdata;
+
+  logic uart_irq;
 
   logic rst_core_n;
   logic ndmreset_req;
@@ -214,7 +217,7 @@ module ibex_super_system #(
      .irq_software_i        (1'b0),
      .irq_timer_i           (timer_irq),
      .irq_external_i        (1'b0),
-     .irq_fast_i            (15'b0),
+     .irq_fast_i            ({14'b0, uart_irq}),
      .irq_nm_i              (1'b0),
 
      .debug_req_i           (dm_debug_req),
@@ -282,6 +285,8 @@ module ibex_super_system #(
     .device_rvalid_o(device_rvalid[Uart]),
     .device_rdata_o (device_rdata[Uart]),
 
+    .uart_rx_i,
+    .uart_irq_o     (uart_irq),
     .uart_tx_o
   );
 

--- a/rtl/system/uart.sv
+++ b/rtl/system/uart.sv
@@ -1,6 +1,8 @@
 module uart #(
   parameter int unsigned ClockFrequency = 50_000_000,
-  parameter int unsigned BaudRate = 115_200
+  parameter int unsigned BaudRate = 115_200,
+  parameter int unsigned RxFifoDepth = 128,
+  parameter int unsigned TxFifoDepth = 128
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -13,52 +15,118 @@ module uart #(
   output logic        device_rvalid_o,
   output logic [31:0] device_rdata_o,
 
+  input  logic        uart_rx_i,
+  output logic        uart_irq_o,
   output logic        uart_tx_o
+  
 );
 
   localparam int unsigned ClocksPerBaud = ClockFrequency / BaudRate;
+  localparam int unsigned UART_RX_REG = 32'h0;
+  localparam int unsigned UART_TX_REG = 32'h4;
+  localparam int unsigned UART_STATUS_REG = 32'h8;
 
-  logic [$clog2(ClocksPerBaud)-1:0] baud_counter_q, baud_counter_d;
-  logic                             baud_tick;
-
-  localparam int unsigned UART_TX_REG = 32'h0;
-  localparam int unsigned UART_STATUS_REG = 32'h4;
+  logic        device_req_q;
+  logic [11:0] reg_addr;
+  logic        read_req, write_req;
+  logic        rx_req, tx_req, status_req;
 
   typedef enum logic[1:0] {
     IDLE,
     START,
-    SEND,
+    PROC,
     STOP
   } uart_state_t;
 
-  uart_state_t state_q, state_d;
-  logic [2:0] bit_counter_q, bit_counter_d;
-  logic [7:0] current_byte_q, current_byte_d;
-  logic       next_tx_byte;
-  logic       read_status_q, read_status_d;
-  logic       req;
+  logic        status_read_req_q, status_read_req_d;
 
-  logic [11:0] reg_addr;
+  logic [$clog2(RxFifoDepth+1)-1:0] rx_fifo_depth;
+  logic [$clog2(ClocksPerBaud)-1:0] rx_baud_counter_q, rx_baud_counter_d;
+  logic                             rx_baud_tick;
 
-  logic       tx_fifo_wvalid;
-  logic       tx_fifo_rvalid, tx_fifo_rready;
-  logic [7:0] tx_fifo_rdata;
-  logic       tx_fifo_full;
+  uart_state_t rx_state_q, rx_state_d;
+  logic [2:0]  rx_bit_counter_q, rx_bit_counter_d;
+  logic [7:0]  rx_current_byte_q, rx_current_byte_d;
+  logic        rx_read_req_q, rx_read_req_d;
+  logic        rx_q, rx_q2, rx_q3, rx_start, rx_valid; 
+
+  logic        rx_fifo_wvalid;
+  logic        rx_fifo_rvalid, rx_fifo_rready;
+  logic [7:0]  rx_fifo_rdata;
+  logic        rx_fifo_empty;
+  
+  logic [$clog2(ClocksPerBaud)-1:0] tx_baud_counter_q, tx_baud_counter_d;
+  logic                             tx_baud_tick;
+  
+  uart_state_t tx_state_q, tx_state_d;
+  logic [2:0]  tx_bit_counter_q, tx_bit_counter_d;
+  logic [7:0]  tx_current_byte_q, tx_current_byte_d;
+  logic        tx_next_byte;
+
+  logic        tx_fifo_wvalid;
+  logic        tx_fifo_rvalid, tx_fifo_rready;
+  logic [7:0]  tx_fifo_rdata;
+  logic        tx_fifo_full;
 
   assign reg_addr = device_addr_i[11:0];
+  
+  assign read_req = (device_req_i & device_be_i[0] & ~device_we_i);
+  assign write_req = (device_req_i & device_be_i[0] & device_we_i);
+  
+  assign rx_req = (reg_addr == $bits(reg_addr)'(UART_RX_REG));
+  assign tx_req = (reg_addr == $bits(reg_addr)'(UART_TX_REG));
+  assign status_req = (reg_addr == $bits(reg_addr)'(UART_STATUS_REG));
+  assign rx_read_req_d = rx_req & read_req;
+  assign status_read_req_d = status_req & read_req;
 
-  assign tx_fifo_wvalid = (device_req_i & (reg_addr == UART_TX_REG) & device_be_i[0] & device_we_i);
-  assign tx_fifo_rready = baud_tick & next_tx_byte;
+  assign device_rdata_o = (rx_read_req_q & rx_fifo_rvalid) ? {24'b0, rx_fifo_rdata} :
+                          status_read_req_q ? {30'b0, tx_fifo_full, rx_fifo_empty} : 
+                          32'b0;
+  assign device_rvalid_o = device_req_q;
 
-  assign read_status_d = (device_req_i & (reg_addr == UART_STATUS_REG) & device_be_i[0] & ~device_we_i);
+  assign rx_fifo_wvalid = rx_baud_tick & rx_valid;
+  assign rx_fifo_rready = rx_read_req_q;
+  assign rx_fifo_empty  = (rx_fifo_depth == '0);
 
-  assign device_rdata_o = read_status_q ? {31'b0, tx_fifo_full} : 32'b0;
-  assign device_rvalid_o = req;
+  assign tx_fifo_wvalid = tx_req & write_req;
+  assign tx_fifo_rready = tx_baud_tick & tx_next_byte;
+
+  // Set the rx_baud_counter half-way on rx_start to ensure sampling the bits 'in the middle'
+  assign rx_baud_counter_d = rx_baud_tick ? '0 : 
+                             rx_start ? $bits(rx_baud_counter_q)'(ClocksPerBaud >> 1) : 
+                             rx_baud_counter_q + 1'b1;
+  assign rx_baud_tick      = rx_baud_counter_q == $bits(rx_baud_counter_q)'(ClocksPerBaud - 1);
+
+  assign tx_baud_counter_d = tx_baud_tick ? '0 : tx_baud_counter_q + 1'b1;
+  assign tx_baud_tick      = tx_baud_counter_q == $bits(tx_baud_counter_q)'(ClocksPerBaud - 1);
+
+  assign uart_irq_o        = !rx_fifo_empty;
 
   prim_fifo_sync #(
     .Width(8),
     .Pass(1'b0),
-    .Depth(128)
+    .Depth(RxFifoDepth)
+  ) u_rx_fifo (
+    .clk_i,
+    .rst_ni,
+    .clr_i(1'b0),
+
+    .wvalid_i(rx_fifo_wvalid),
+    .wready_o(),
+    .wdata_i(rx_current_byte_q),
+
+    .rvalid_o(rx_fifo_rvalid),
+    .rready_i(rx_fifo_rready),
+    .rdata_o(rx_fifo_rdata),
+
+    .full_o(),
+    .depth_o(rx_fifo_depth)
+  );
+
+  prim_fifo_sync #(
+    .Width(8),
+    .Pass(1'b0),
+    .Depth(TxFifoDepth)
   ) u_tx_fifo (
     .clk_i,
     .rst_ni,
@@ -76,73 +144,144 @@ module uart #(
     .depth_o()
   );
 
-  assign baud_counter_d = baud_tick ? '0 : baud_counter_q + 1'b1;
-  assign baud_tick      = baud_counter_q == (ClocksPerBaud - 1);
+  //  Synchronize RX and derive rx_start signal
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rx_q <= 0;
+      rx_q2 <= 0;
+      rx_q3 <= 0;
+    end else begin
+      rx_q <= uart_rx_i;
+      rx_q2 <= rx_q;
+      rx_q3 <= rx_q2;
+    end
+  end
+
+  assign rx_start = !rx_q2 & rx_q3 & (rx_state_q == IDLE);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      read_status_q  <= 0;
-      req            <= 0;
-      baud_counter_q <= '0;
+      status_read_req_q <= 0;
+      device_req_q      <= 0;
+      rx_read_req_q     <= 0;
+      rx_baud_counter_q <= '0;
+      tx_baud_counter_q <= '0;
     end else begin
-      read_status_q  <= read_status_d;
-      req            <= device_req_i;
-      baud_counter_q <= baud_counter_d;
+      status_read_req_q <= status_read_req_d;
+      device_req_q      <= device_req_i;
+      rx_read_req_q     <= rx_read_req_d;
+      rx_baud_counter_q <= rx_baud_counter_d;
+      tx_baud_counter_q <= tx_baud_counter_d;
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      state_q        <= IDLE;
-      bit_counter_q  <= '0;
-      current_byte_q <= '0;
-    end else if (baud_tick) begin
-      state_q        <= state_d;
-      bit_counter_q  <= bit_counter_d;
-      current_byte_q <= current_byte_d;
+      rx_state_q        <= IDLE;
+      rx_bit_counter_q  <= '0;
+      rx_current_byte_q <= '0;
+    // Transition the rx state on both rx_start and an rx_baud_tick
+    end else if (rx_start | rx_baud_tick) begin
+      rx_state_q        <= rx_state_d;
+      rx_bit_counter_q  <= rx_bit_counter_d;
+      rx_current_byte_q <= rx_current_byte_d;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tx_state_q        <= IDLE;
+      tx_bit_counter_q  <= '0;
+      tx_current_byte_q <= '0;
+    end else if (tx_baud_tick) begin
+      tx_state_q        <= tx_state_d;
+      tx_bit_counter_q  <= tx_bit_counter_d;
+      tx_current_byte_q <= tx_current_byte_d;
     end
   end
 
   always_comb begin
-    uart_tx_o      = 1'b0;
-    bit_counter_d  = bit_counter_q;
-    current_byte_d = current_byte_q;
-    next_tx_byte   = 1'b0;
-    state_d        = state_q;
+    rx_valid          = 0;
+    rx_bit_counter_d  = rx_bit_counter_q;
+    rx_current_byte_d = rx_current_byte_q;
+    rx_state_d        = rx_state_q;
 
-    case (state_q)
+    case (rx_state_q)
+      IDLE: begin
+
+        if (rx_start) begin
+          rx_state_d = START;
+        end
+      end
+      START: begin
+        rx_current_byte_d = '0;
+        rx_bit_counter_d = '0;
+        
+        if (!rx_q3) begin
+          rx_state_d = PROC;
+        end else begin
+          rx_state_d = IDLE;
+        end
+      end
+      PROC: begin
+        rx_current_byte_d = {rx_q3, rx_current_byte_q[7:1]};
+
+        if (rx_bit_counter_q == 3'd7) begin
+          rx_state_d = STOP;
+        end else begin
+          rx_bit_counter_d = rx_bit_counter_q + 3'd1;
+        end
+      end
+      STOP: begin
+        if (rx_q3) begin
+          rx_valid = 1;
+        end
+        rx_state_d = IDLE;
+      end
+    endcase
+  end
+
+  always_comb begin
+    uart_tx_o         = 1'b0;
+    tx_bit_counter_d  = tx_bit_counter_q;
+    tx_current_byte_d = tx_current_byte_q;
+    tx_next_byte      = 1'b0;
+    tx_state_d        = tx_state_q;
+
+    case (tx_state_q)
       IDLE: begin
         uart_tx_o = 1'b1;
 
         if (tx_fifo_rvalid) begin
-          state_d = START;
+          tx_state_d = START;
         end
       end
       START: begin
-        uart_tx_o      = 1'b0;
-        state_d        = SEND;
-        bit_counter_d  = 3'd0;
-        current_byte_d = tx_fifo_rdata;
-        next_tx_byte   = 1'b1;
+        uart_tx_o         = 1'b0;
+        tx_state_d        = PROC;
+        tx_bit_counter_d  = 3'd0;
+        tx_current_byte_d = tx_fifo_rdata;
+        tx_next_byte      = 1'b1;
       end
-      SEND: begin
-        uart_tx_o = current_byte_q[0];
+      PROC: begin
+        uart_tx_o = tx_current_byte_q[0];
 
-        current_byte_d = {1'b0, current_byte_q[7:1]};
-        if (bit_counter_q == 3'd7) begin
-          state_d = STOP;
+        tx_current_byte_d = {1'b0, tx_current_byte_q[7:1]};
+        if (tx_bit_counter_q == 3'd7) begin
+          tx_state_d = STOP;
         end else begin
-          bit_counter_d = bit_counter_q + 3'd1;
+          tx_bit_counter_d = tx_bit_counter_q + 3'd1;
         end
       end
       STOP: begin
         uart_tx_o = 1'b1;
         if (tx_fifo_rvalid) begin
-          state_d = START;
+          tx_state_d = START;
         end else begin
-          state_d = IDLE;
+          tx_state_d = IDLE;
         end
       end
     endcase
   end
+
 endmodule

--- a/sw/common/super_system.c
+++ b/sw/common/super_system.c
@@ -11,6 +11,10 @@ int putchar(int c) {
   return c;
 }
 
+int getchar(void) {
+  return uart_in(DEFAULT_UART);
+}
+
 int puts(const char *str) {
   while (*str) {
     putchar(*str++);

--- a/sw/common/super_system.h
+++ b/sw/common/super_system.h
@@ -24,6 +24,14 @@
 int putchar(int c);
 
 /**
+ * Reads character from default UART. Signature matches c stdlib function
+ * of the same name.
+ *
+ * @returns Character from the uart rx fifo
+ */
+int getchar(void);
+
+/**
  * Writes string to default UART. Signature matches c stdlib function of
  * the same name.
  *

--- a/sw/common/uart.c
+++ b/sw/common/uart.c
@@ -1,8 +1,37 @@
+#include "stdio.h"
 #include "uart.h"
 #include "dev_access.h"
+#include "super_system.h"
 
-void uart_out(void* uart_ptr, char c) {
-  while(DEV_READ(uart_ptr + UART_STATUS_REG) & UART_STATUS_TX_FULL);
+void simple_uart_in_handler(void) __attribute__((interrupt));
 
-  DEV_WRITE(uart_ptr + UART_TX_REG, c);
+void simple_uart_in_handler(void) {
+  while (!(DEV_READ(DEFAULT_UART + UART_STATUS_REG) & UART_STATUS_RX_EMPTY)) {
+    DEV_WRITE(DEFAULT_UART + UART_TX_REG, DEV_READ(DEFAULT_UART + UART_RX_REG));
+  }
+}
+
+void uart_init(void) {
+  install_exception_handler(16, &simple_uart_in_handler);
+}
+
+void uart_enable(void) {
+  // enable uart interrupt
+  asm volatile("csrs  mie, %0\n" : : "r"(1<<16));
+  // enable global interrupt
+  asm volatile("csrs  mstatus, %0\n" : : "r"(1<<3));
+}
+
+int uart_in(uart_t uart) {
+  int res = EOF;
+  if (!(DEV_READ(uart + UART_STATUS_REG) & UART_STATUS_RX_EMPTY)) {
+    res = DEV_READ(uart + UART_RX_REG);
+  }
+  return res;
+}
+
+void uart_out(uart_t uart, char c) {
+  while(DEV_READ(uart + UART_STATUS_REG) & UART_STATUS_TX_FULL);
+
+  DEV_WRITE(uart + UART_TX_REG, c);
 }

--- a/sw/common/uart.h
+++ b/sw/common/uart.h
@@ -1,15 +1,20 @@
 #ifndef UART_H__
 #define UART_H__
 
-#define UART_TX_REG 0
-#define UART_STATUS_REG 4
+#define UART_RX_REG 0
+#define UART_TX_REG 4
+#define UART_STATUS_REG 8
 
-#define UART_STATUS_TX_FULL 1
+#define UART_STATUS_RX_EMPTY 1
+#define UART_STATUS_TX_FULL 2
 
 typedef void* uart_t;
 
 #define UART_FROM_BASE_ADDR(addr)((uart_t)(addr))
 
+void uart_init(void);
+void uart_enable(void);
+int uart_in(uart_t uart);
 void uart_out(uart_t uart, char c);
 
 #endif // UART_H__

--- a/sw/demo/main.c
+++ b/sw/demo/main.c
@@ -2,7 +2,15 @@
 #include "timer.h"
 #include "gpio.h"
 
+// Comment out the line below to disable the RX interrupt and 
+// have the ibex_super_system generate the text written to TX
+#define UART_RX_ENABLED
+
 int main(void) {
+  #ifdef UART_RX_ENABLED
+  uart_init();
+  uart_enable();    
+  #endif
   timer_init();
   timer_enable(50000000);
 
@@ -17,9 +25,11 @@ int main(void) {
 
     if (cur_time != last_elapsed_time) {
       last_elapsed_time = cur_time;
+      #ifndef UART_RX_ENABLED
       puts("Hello World! ");
       puthex(last_elapsed_time);
       putchar('\n');
+      #endif
       set_output_bit(GPIO0, cur_output_bit_index, cur_output_bit);
 
       cur_output_bit_index++;

--- a/sw/demo/uart_hello.py
+++ b/sw/demo/uart_hello.py
@@ -1,0 +1,48 @@
+import time
+import serial
+import serial.tools.list_ports
+
+TRIES = 100
+
+
+def get_port():
+    port_list = [i.device for i in list(serial.tools.list_ports.comports())]
+    ports = sorted(port_list, reverse=True)
+    if len(ports) == 1:
+        return ports[0]
+    else:
+        print("Available ports:")
+        for idx, port in enumerate(ports):
+            print(f"{idx+1: <3} : {port}")
+        selection = 0
+        while selection not in range(1, len(ports) + 1):
+            try:
+                selection = int(input("Please select a serial device: "))
+            except ValueError:
+                pass
+        return ports[selection - 1]
+
+
+def main():
+    try:
+        device = serial.Serial(port=get_port(), baudrate=115200)
+    except serial.serialutil.SerialException:
+        print('Unable to open serial port')
+    else:
+        error_count = 0
+        device.reset_input_buffer()
+        device.reset_output_buffer()
+        time.sleep(0.010)
+        for i in range(TRIES):
+            send_bytes = f"Hello world ({i})".encode('utf-8')
+            recv_bytes = device.read(device.write(send_bytes))
+            print(f"Send: {send_bytes}\tReceived: {recv_bytes}")
+            if recv_bytes != send_bytes:
+                error_count += 1
+        print(f"tries = {TRIES}")
+        print(f"error_count = {error_count}")
+        print(f"error_rate = {100 * (error_count/TRIES)}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/arty-a7-openocd-cfg.tcl
+++ b/util/arty-a7-openocd-cfg.tcl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-interface ftdi
+adapter driver ftdi
 transport select jtag
 
 ftdi_device_desc "Digilent USB Device"
@@ -14,7 +14,13 @@ reset_config none
 # Configure JTAG chain and the target processor
 set _CHIPNAME riscv
 
-jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x0362D093 -ignore-version
+# Configure JTAG expected ID
+# arty-a7-35t
+set _EXPECTED_ID 0x0362D093 
+# arty-a7-100t
+# set _EXPECTED_ID 0x13631093 
+
+jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id $_EXPECTED_ID -ignore-version
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
@@ -22,7 +28,7 @@ riscv set_ir idcode 0x09
 riscv set_ir dtmcs 0x22
 riscv set_ir dmi 0x23
 
-adapter_khz 10000
+adapter speed 10000
 
 riscv set_prefer_sba on
 gdb_report_data_abort enable


### PR DESCRIPTION
Please consider merging in these changes. 

There are 2 commits:
1) Updates the arty a7  config file
    - Replaces some deprecated statements
    - Adds an (optional) switch for using an arty a7-100t board (instead of the default a7-35t board).
 2) Adds RX functionality to the UART.
    - Updates both the hardware and the software.
    - The demo has been updated to (optionally) echo the RX data to the TX data (this is the default).
    - An addtional python file (using pyserial) is included to test the super-system echoing the RX input.

Possible point of attention:
In the software there is a 'circular include'. super_system includes uart and uart includes super_system.
This is not an issue because of the ifndef guards., but I am unsure if this is acceptable.

Tested set of commands to verify the functionality of this commit:
```
rm -rf build
rm -rf sw/build/
(cd sw && mkdir -p build && cd build && cmake ../ && make)
fusesoc --cores-root=. run --target=synth --setup --build lowrisc:ibex:super_system --part xc7a100tcsg324-1
make -C ./build/lowrisc_ibex_super_system_0/synth-vivado/ pgm
./util/load_super_system.sh run ./sw/build/demo/demo
python ./sw/demo/uart_hello.py
```
NOTES:
1) This is for an Arty-A7-100T board. For an Arty A7-35T board, don't include "--part xc7a100tcsg324-1"
2) At the moment Fusesoc cannot be used directly for programming the FPGA. This is replaced with "make -C ./build/lowrisc_ibex_super_system_0/synth-vivado/ pgm". A pull request to fix this issue can be found here: https://github.com/olofk/edalize/pull/319

