### PR TITLE
Improve python dependencies, license and readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -176,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Greg Chadwick
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -87,12 +87,15 @@ debugger.
 ./util/load_super_system.sh halt ./sw/build/demo/demo
 ```
 
-To view terminal output use screen
+To view terminal output use screen:
 
 ```bash
 # Look in /dev to see available ttyUSB devices
 screen /dev/ttyUSB1 115200
 ```
+
+If you see an immediate `[screen is terminating]`, it may mean that you need super user rights.
+In this case, you may try using `sudo`.
 
 ## Debugging a program
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ source ./bin/activate
 pip3 install -r python-requirements.txt
 ```
 
+You may need to run the last command twice if you get the following error:
+`ERROR: Failed building wheel for fusesoc`
+
 ## Building
 
 First the software must be built. This is provide an initial binary for the FPGA

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Or use the Vivado GUI
 make -C ./build/lowrisc_ibex_super_system_0/synth-vivado/ build-gui
 ```
 
+Inside Vivado you do not have to run the synthesis, the implementation or generate the bitstream.
+Simply click on "Open Hardware Manager", then on "Auto Connect" and finally on "Program Device".
+
 ## Loading a program
 
 The util/load_super_system.sh script can be used to load and run a program. You

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -2,11 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Individual Python packages
+anytree
+mako
+pyyaml
+wheel
+
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot
 
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot
 
-pyyaml
-mako


### PR DESCRIPTION
- Add wheel and anytree to the Python requirements.
- Added a note on possibly needing `sudo` for screen.
- Added a note on possibly needing to install python requirements twice.
- Added year and owner to licence.
- Added instructions to program device in Vivado.